### PR TITLE
(smart-probe) Validate response body before accepting dataset

### DIFF
--- a/custom_components/silam_pollen/config_flow.py
+++ b/custom_components/silam_pollen/config_flow.py
@@ -248,8 +248,12 @@ class SilamPollenConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         async with session.get(test_url) as response:
                             text = await response.text()
                             if response.status == 200:
-                                chosen_url = url
-                                return True, None, chosen_url
+                                if text and text.strip():
+                                    chosen_url = url
+                                    return True, None, chosen_url
+                                else:
+                                    _LOGGER.debug("API returned 200 but empty response from %s", url)
+                                    last_response = "HTTP 200 but empty response (coordinates outside grid?)"
                             else:
                                 last_response = text
                                 _LOGGER.debug("API returned %s from %s: %s", response.status, url, text)
@@ -357,7 +361,10 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                     async with async_timeout.timeout(10):
                         async with session.get(test_url) as response:
                             if response.status == 200:
-                                return url
+                                text = await response.text()
+                                if text and text.strip():
+                                    return url
+                                _LOGGER.debug("SMART probe: 200 but empty response from %s", url)
                 except Exception as err:
                     _LOGGER.debug("SMART probe exception when requesting %s: %s", url, str(err))
 
@@ -377,7 +384,10 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         try:
             async with async_timeout.timeout(10):
                 async with session.get(test_url) as response:
-                    return response.status == 200
+                    if response.status != 200:
+                        return False
+                    text = await response.text()
+                    return bool(text and text.strip())
         except Exception as err:
             _LOGGER.debug("Availability check failed for %s (%s): %s", dataset_name, test_url, err)
             return False

--- a/custom_components/silam_pollen/coordinator.py
+++ b/custom_components/silam_pollen/coordinator.py
@@ -367,7 +367,21 @@ class SilamCoordinator(DataUpdateCoordinator):
                 async with async_timeout.timeout(10):
                     async with session.get(test_url) as resp:
                         if resp.status == 200:
-                            return url
+                            txt = await resp.text()
+                            if txt and txt.strip():
+                                try:
+                                    ET.fromstring(txt)
+                                    return url
+                                except ET.ParseError:
+                                    _LOGGER.debug(
+                                        "%s SMART probe skip %s: HTTP 200 but invalid XML",
+                                        self._log_prefix, url,
+                                    )
+                            else:
+                                _LOGGER.debug(
+                                    "%s SMART probe skip %s: HTTP 200 but empty response",
+                                    self._log_prefix, url,
+                                )
             except Exception as err:
                 _LOGGER.debug("%s SMART probe failed for %s: %s", self._log_prefix, url, err)
 
@@ -435,8 +449,28 @@ class SilamCoordinator(DataUpdateCoordinator):
 
                 async with async_timeout.timeout(10):
                     txt = await resp.text()
+
+                # HTTP 200 but empty/whitespace-only body means the
+                # coordinates fall outside the dataset's spatial grid.
+                if not txt or not txt.strip():
+                    _LOGGER.debug(
+                        "%s SMART coord probe: HTTP 200 but empty response for %s",
+                        self._log_prefix, base_url,
+                    )
+                    self._smart_coord_ok[base_url] = False
+                    return False
+
                 # Пробуем распарсить XML, если получилось — это покрытие
-                ET.fromstring(txt)
+                try:
+                    ET.fromstring(txt)
+                except ET.ParseError:
+                    _LOGGER.debug(
+                        "%s SMART coord probe: HTTP 200 but invalid XML for %s",
+                        self._log_prefix, base_url,
+                    )
+                    self._smart_coord_ok[base_url] = False
+                    return False
+
                 self._smart_coord_ok[base_url] = True
                 return True
 


### PR DESCRIPTION
THREDDS NCSS returns HTTP 200 with an empty body for coordinates outside a dataset's spatial grid. The SMART probe logic only checked status code, causing it to select datasets that don't actually cover the user's location (e.g. Northern Europe v5.9.1 for Trier, Germany).

Validate that HTTP 200 responses contain non-empty, parseable XML before accepting a dataset in all five probe paths: coordinator's _smart_select_base_url and _smart_probe_coord_coverage, and config_flow's _test_api, _probe_best_base_url, and _is_dataset_available.

Fixes danishru/silam_pollen#25